### PR TITLE
Revert "have bot post on build completion, not on commit"

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -68,7 +68,7 @@ steps:
 - title: Specify the docker image
   description: Specify the docker image.
   link: '{{ repoUrl }}/pull/2'
-  event: status
+  event: pull_request.synchronize
   actions:
   - type: respond
     with: 03.1_new-status.md
@@ -164,7 +164,7 @@ steps:
 - title: Fix the broken build
   description: Fix any broken links currently in our codebase.
   link: '{{ repoUrl }}/pull/3'
-  event: status
+  event: pull_request.synchronize
   actions:
   # explaining waiting for the build, merge when done
   - type: respond
@@ -210,7 +210,7 @@ steps:
 - title: Add an HTMLProofer unit test
   description: Check for broken links using CI.
   link: '{{ repoUrl }}/pull/4'
-  event: status #PR 5 with the addition of a unit test
+  event: pull_request.synchronize #PR 5 with the addition of a unit test
   actions:
   # merge a broken link into the branch
   - type: mergeBranch

--- a/responses/02.1_build-status.md
+++ b/responses/02.1_build-status.md
@@ -25,4 +25,4 @@ To get the CI build to succeed, replace the placeholder text and commit the chan
 <hr>
 <h3 align="center">I'll respond below with your next step.</h3>
 
-> _I'll respond once the build finishes. It might take a few minutes. If you perform an expected action and don't see a response, wait and refresh the page for your next steps._
+> _Sometimes I respond too fast for the page to update! If you perform an expected action and don't see a response, wait a few seconds and refresh the page for your next steps._

--- a/responses/06.1_branch-protected.md
+++ b/responses/06.1_branch-protected.md
@@ -25,5 +25,3 @@ Let's find the broken syntax and fix the build!
 
 <hr>
 <h3 align="center">I'll respond below with your next step.</h3>
-
-> _I'll respond once the build finishes. It might take a few minutes. If you perform an expected action and don't see a response, wait and refresh the page for your next steps._

--- a/responses/08.1_feature.md
+++ b/responses/08.1_feature.md
@@ -16,5 +16,3 @@ Let's make sure all links are valid by adding a link checker unit test.
 
 <hr>
 <h3 align="center">I'll respond below with your next step.</h3>
-
-> _I'll respond once the build finishes. It might take a few minutes. If you perform an expected action and don't see a response, wait and refresh the page for your next steps._


### PR DESCRIPTION
This reverts commit 6003012ec24a2857e8e081a43a25dcd44a1230c8. This commit was waiting for the deploy to respond, but now it's going to go back to waiting for the PR to be updated. I'm not sure why it was a problem to wait for "status" but it doesn't work as I'd expect. 