### PR TITLE
Enable branch protection at beginning, and remove before first merge

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -7,7 +7,8 @@ template:
     name: continuous-integration
     repo: ci-circle-template
 before:
-  # open issue 1 (welcome)
+- type: updateBranchProtection
+# open issue 1 (welcome)
 - type: createIssue
   title: Welcome
   body: 00.0_welcome.md
@@ -70,6 +71,7 @@ steps:
   link: '{{ repoUrl }}/pull/2'
   event: pull_request.synchronize
   actions:
+  - type: removeBranchProtection
   - type: respond
     with: 03.1_new-status.md
 


### PR DESCRIPTION
This pull request fixes #61 by enabling branch protection before the first merge, and enabling it right as we ask them to merge. 

cc @hollenberry for 👀 

@hollenberry if this looks good to you, go ahead and 🚢 👍 