### PR TITLE
Gate away pending states

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -34,6 +34,10 @@ steps:
     left: '%payload.context%'
     operator: ===
     right: ci/circleci
+  - type: gate
+    left: '%payload.state%'
+    operator: '!=='
+    right: 'pending'
   # asks user to open a PR
   - type: respond
     issue: Welcome


### PR DESCRIPTION
This PR adds a check for a `pending` state, to prevent acting too quickly against a CI status coming from Circle. Closes #55.

Not sure who to request a review from - will ship with one 👍 