### PR TITLE
More edits for responses based on happy path

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -48,7 +48,7 @@ steps:
 # 2 - Add new code
 - title: Introduce the configuration file
   description: Learn how to use CI by introducing a configuration file.
-  link: '{{ repoUrl }}/issues/1'
+  link: '{{ repoUrl }}/compare/master...initial-circle-config?expand=1'
   event: pull_request.opened
   actions:
   # introduces learner to the build status at the provider page (or the checks tab?), asks learner to commit a fix
@@ -297,6 +297,10 @@ steps:
   link: '{{ repoUrl }}/issues/5'
   event: deployment
   actions:
+  - type: createIssue
+    title: Congratulations
+    body: 12.2_congratulations.md
+    action_id: congratsIssue
   # points the learner to the deployment, constrasts with continuous delivery
   - type: respond
     issue: Continuous deployment
@@ -306,7 +310,3 @@ steps:
   # @todo create additional PRs for continued study
   - type: closeIssue
     issue: Continuous deployment
-  - type: createIssue
-    title: Congratulations
-    body: 12.2_congratulations.md
-    action_id: congratsIssue

--- a/responses/00.0_welcome.md
+++ b/responses/00.0_welcome.md
@@ -23,6 +23,9 @@ The tools that will work best for your project depend on many factors, including
 - Geographic distribution of dependent systems and the people who use them
 - Packaging and delivery goals
 
+### Using CI and Learning Lab
+In other courses, you may have noticed that some actions take me longer to respond to than others. In this course, many of the actions will be related to builds. Those builds sometimes take longer to build, up to several minutes. Don't be concerned if I take a few minutes to respond, or if I respond too quickly. Sometimes, I'll let you know what the build will say before it finishes! Please wait for the builds to finish before moving on to your next step.
+
 ## Step 1: Enable Continuous Integration
 
 Ready to see how CI can fit into your workflow? Let's install CircleCI, and start our very first CI build!
@@ -32,7 +35,7 @@ Ready to see how CI can fit into your workflow? Let's install CircleCI, and star
 ### :keyboard: Activity: Enable CircleCI and run your first build
 
 1. Navigate to CircleCI's [sign in](https://circleci.com/signup/) page in a separate tab.
-1. Sign in with GitHub and set up a build on CircleCI for this repository. You will need to select *Set Up Project* for this repository, and *Start building*. You can ignore the prompts to add a `config.yml` file, as I've already done this for you. 
+1. Sign in with GitHub and set up a build on CircleCI for this repository. You can ignore the prompts to add a `config.yml` file, as I've already done this for you.
     - You can find step by step instructions in [CircleCI's documentation](https://circleci.com/docs/2.0/getting-started/#setting-up-your-build-on-circleci).
 1. Under the **ADD PROJECTS** option in the side-bar menu, click the **Set up Project** button next to the **continuous-integration** project.
 1. Click the **Start building** button on step 5.

--- a/responses/03.1_new-status.md
+++ b/responses/03.1_new-status.md
@@ -1,6 +1,6 @@
-Nice work getting your CI build to succeed! :tada:
+Nice work! Soon, your CI build should succeed! :tada:
 
-It might take a second to finish running, but notice that your pull request shows all checks have passed with 1 successful check. To see more details, you can click "See all checks".
+When the build completes, notice that your pull request shows all checks have passed with 1 successful check. If it isn't showing up green in a few minutes, try refreshing the page. To see more details, you can click "See all checks".
 
 ![screen shot 2018-12-11 at 2 41 48 pm](https://user-images.githubusercontent.com/6351798/49832098-eec78980-fd52-11e8-9092-fb5fa903b793.png)
 

--- a/responses/04.1_customize-the-build.md
+++ b/responses/04.1_customize-the-build.md
@@ -1,5 +1,7 @@
 In this pull request, I've added some tests to help ensure the project builds. This is one example of how you can customize specific validations to run when your CI starts a build. I need you to add a **run action** to your `.circleci/config.yml` file.
 
+In this example, we'll build the project with `bundle exec jekyll build`. Depending on the programming language and project, you might use a different command, like `yarn run android` or `nvm package`. You can find more specific information on CircleCI configuration [in their documentation](https://circleci.com/docs/2.0/tutorials/).
+
 ## Step 5: Add validation
 
 Build your site.

--- a/responses/05.1_protect-branch.md
+++ b/responses/05.1_protect-branch.md
@@ -1,4 +1,4 @@
-Now that you've added some validation tests to your CI build, it's time to turn on some branch protections. Protected branches ensure that collaborators cannot make irrevocable changes to specific branches. This also allows you to enable CI required status checks to pass before merging.
+Now that you've added some validation tests to your CI build, it's time to turn edit the branch protections. Protected branches ensure that collaborators cannot make irrevocable changes to specific branches. This also allows you to enable CI required status checks to pass before merging.
 
 ![screen shot 2018-12-13 at 3 32 04 pm](https://user-images.githubusercontent.com/6351798/49971616-4baa7780-feec-11e8-950e-cce1985531d9.png)
 
@@ -8,10 +8,10 @@ I've changed the protections for the `master` branch throughout the course so fa
 
 ### :keyboard: Activity: Protect a branch based on the CI build status
 
-1. Navigate to the [**Settings** tab](https://github.com/{{ user.username }}/{{ repo }}/settings) of this repository.
-1. Under **Branches**, click **Add rule**.
-1. Apply rule to the `master` branch, then select **Require status checks to pass before merging**, and then select the **ci/circleci:build** option.
-1. Return to your pull request and [**Approve the pull request**]((https://github.com/{{ user.username }}/{{ repo }}/pull/3/files#submit-review)).
+1. Navigate to the []**Branches** section of the Settings](https://github.com/{{ user.username }}/{{ repo }}/settings/branches) for this repository.
+1. Under **Branch protection rules**, click the **Edit** button next to `master`.
+1. Select **Require status checks to pass before merging**, and then select the **ci/circleci:buildandtest** option.
+1. Return to your pull request and [**Approve the pull request**](https://github.com/{{ user.username }}/{{ repo }}/pull/3/files#submit-review).
 
 <hr>
 <h3 align="center">I'll respond below with your next step.</h3>


### PR DESCRIPTION
More edits! I'll merge quickly, but here are my original notes in case you'd like to know the details. 


> Note: @hollenberry @a-a-ron @beardofedu if you come across this while testing, it's not a bug. It's on purpose, and this will match accurately after an update to the template repository that @ppremk is working on.

The "template" things aren't taken care of yet, but we can handle those later. 

### Template
- [ ] filter-base the template repo -> and we'll need to change line 167 of config to `right: "circle-ci: buildandtest"`

- [ ] Do we want to have a PR template?
  - First PR is adding initial circle config

- [ ] Why is step merging master into custom build? That's what's taking a long time. To avoid this, template repository `custom-build` branch should have `- image: circleci/ruby:2.4.1-node-browsers`. All branches except for initial-circle-config should have `- image: circleci/ruby:2.4.1-node-browsers`. `timestamp` doesn't matter. 


### Responses
- [x] First trigger took a long time. Maybe our first comment can include something like:
  - "In other courses, you may have noticed that some actions take me longer to respond to than others. In this course, many of the actions will be related to builds. Those builds sometimes take longer to build, up to several minutes. Don't be concerned if I take a few minutes to respond, or if I respond too quickly. Sometimes, I'll let you know what the build will say before it finishes! Please wait for the builds to finish before moving on to your next step."
- [x] 0.0: Sign in with GitHub and set up a build on CircleCI for this repository. You will need to select Set Up Project for this repository, and Start building. You can ignore the prompts to add a config.yml file, as I've already done this for you.> "Sign in with GitHub and set up a build on CircleCI for this repository. Ignore the prompts to add a config.yml file, as I've already done this for you."

- [x] Config step 2 link should be : https://github.com/brianamarie/continuous-integration/compare/master...initial-circle-config?expand=1

- [x] Step where we have "Step 5" we should also include something like: "In this example, we'll build the project with `bundle exec jekyll build`. Depending on the programming language and project, you might use a different command, like `yarn run android` or `nvm package`. You can find more specific information on CircleCI configuration [in their documentation](https://circleci.com/docs/2.0/tutorials/)."

- [x] Instructions should cover only one test, "buildandtest", starts where it says "Step 6:".



- [x] Change instructions that are posted in step 5 for step 6 to have user edit the protected branches.

- [x] Response 3.something: "Nice work getting your CI build to succeed! 🎉

It might take a second to finish running, but notice that your pull request shows all checks have passed with 1 successful check. If it isn't showing up green in a few minutes, try refreshing the page. To see more details, you can click "See all checks"." > "Nice work! Soon, your CI build should succeed! :tada:

When the build completes, notice that your pull request shows all checks have passed with 1 successful check. If it isn't showing up green in a few minutes, try refreshing the page. To see more details, you can click "See all checks"."


- [x] "Now that you've added some validation tests to your CI build, it's time to turn on some branch protections. Protected branches ensure that collaborators cannot make irrevocable changes to specific branches. This also allows you to enable CI required status checks to pass before merging." > "Now that you've added some validation tests to your CI build, it's time to turn edit the branch protections. Protected branches ensure that collaborators cannot make irrevocable changes to specific branches. This also allows you to enable CI required status checks to pass before merging."
- [x] "Navigate to the Settings tab of this repository.
Under Branches, click Add rule.
Apply rule to the master branch, then select Require status checks to pass before merging, and then select the ci/circleci:build option.
Return to your pull request and Approve the pull request." >
"1. Navigate to the Branches section of the Settings for this repository.
1. Under **Branch protection rules**, click the **Edit** button next to `master`.
1. Select **Require status checks to pass before merging**, and then select the **ci/circleci:buildandtest** option.

Return to your pull request and Approve the pull request." >>>> #TODO url for settings needs /branches at the end!

- [x] Last response, I'll respond in your next issue, should point to issue 6
