### PR TITLE
Update 05.1_protect-branch.md

### DIFF
--- a/responses/05.1_protect-branch.md
+++ b/responses/05.1_protect-branch.md
@@ -2,7 +2,7 @@ Now that you've added some validation tests to your CI build, it's time to turn 
 
 <details>
     <summary>Why use protected branches?</summary>
-    Protected branches enable you to allow other contributors to create branches and suggest changes to your repository, while making sure those changes are throughly reviewed before being merged in. While protected branches is a <b>great</b> way to ensure changes are being tested, utilizing a continuous integration services like Circle CI provides an <i>automated</i> process for testing any changes being suggested, as they are being suggested.  
+    Protected branches allow contributors to create branches and pull requests in your repository, while making sure those changes are throughly vetted before merging. When a repository employs a continuous integration service like CircleCI, branches can be protected based on their build statuses so the review process can be largely <i>automated</i>, giving contributors self-efficacy. Project maintainers also benefit by focusing their attention on gray areas and processes that can't be easily automated.  
 </details>
 
 ![screen shot 2018-12-13 at 3 32 04 pm](https://user-images.githubusercontent.com/6351798/49971616-4baa7780-feec-11e8-950e-cce1985531d9.png)


### PR DESCRIPTION
Closes #104 

Adding the "why" for protected branches. I thought I was going to make it a long "why" so I threw it in a drop-down, I think it might be ok as a non-drop-down sentence. 